### PR TITLE
Adjust form to auth forms usage

### DIFF
--- a/.changeset/kind-zoos-cheer.md
+++ b/.changeset/kind-zoos-cheer.md
@@ -1,0 +1,7 @@
+---
+"@utima/ui-informed": patch
+---
+
+- Add prop `hideOptional` to FormControl to hide 'optional' flag on labels
+- Add prop `inputType` to Input to distinguish between input type and form control type
+- Add prop `disableDefaultToast` to Form to disable default toast messages on submit

--- a/packages/ui-informed/src/controls/input/Input.tsx
+++ b/packages/ui-informed/src/controls/input/Input.tsx
@@ -1,33 +1,36 @@
 import { Input as InputUI } from '@utima/ui';
-import type { ComponentProps, HTMLInputTypeAttribute } from 'react';
+import type { ComponentProps } from 'react';
 
 import { FormControl } from '../../formControl/FormControl';
 
-type InputControlProps = Omit<ComponentProps<typeof FormControl>, 'render'> & {
-  // Needs revisit, type conflicts with HTMLInputTypeAttribute
-  // Will be fixed in @utima/informed-ui lib
-  inputType?: HTMLInputTypeAttribute;
-};
+type InputControlProps = Omit<ComponentProps<typeof FormControl>, 'render'>;
 
 /**
  * Input component that is controlled by Informed. It is a wrapped in the
  * `FormControl` component, which provides the necessary props for Informed to
  * work along with label and error message handling.
  */
-export function Input({
-  type = 'text',
-  inputType,
-  ...restProps
-}: InputControlProps) {
+export function Input({ type = 'text', ...restProps }: InputControlProps) {
+  let formInputType: string;
+  switch (type) {
+    case 'textArea':
+    case 'number':
+      formInputType = type;
+      break;
+
+    default:
+      formInputType = 'text';
+  }
+
   return (
     <FormControl
       {...restProps}
-      type={type}
+      type={formInputType}
       render={({ field: { ref, userProps, informed, fieldState } }) => (
         <InputUI
           ref={ref}
           variant={fieldState.showError ? 'danger' : 'default'}
-          type={inputType ?? type}
+          type={type}
           {...userProps}
           {...informed}
         />

--- a/packages/ui-informed/src/controls/input/Input.tsx
+++ b/packages/ui-informed/src/controls/input/Input.tsx
@@ -1,16 +1,24 @@
 import { Input as InputUI } from '@utima/ui';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, HTMLInputTypeAttribute } from 'react';
 
 import { FormControl } from '../../formControl/FormControl';
 
-type InputControlProps = Omit<ComponentProps<typeof FormControl>, 'render'>;
+type InputControlProps = Omit<ComponentProps<typeof FormControl>, 'render'> & {
+  // Needs revisit, type conflicts with HTMLInputTypeAttribute
+  // Will be fixed in @utima/informed-ui lib
+  inputType?: HTMLInputTypeAttribute;
+};
 
 /**
  * Input component that is controlled by Informed. It is a wrapped in the
  * `FormControl` component, which provides the necessary props for Informed to
  * work along with label and error message handling.
  */
-export function Input({ type = 'text', ...restProps }: InputControlProps) {
+export function Input({
+  type = 'text',
+  inputType,
+  ...restProps
+}: InputControlProps) {
   return (
     <FormControl
       {...restProps}
@@ -19,7 +27,7 @@ export function Input({ type = 'text', ...restProps }: InputControlProps) {
         <InputUI
           ref={ref}
           variant={fieldState.showError ? 'danger' : 'default'}
-          type={type}
+          type={inputType ?? type}
           {...userProps}
           {...informed}
         />

--- a/packages/ui-informed/src/form/Form.tsx
+++ b/packages/ui-informed/src/form/Form.tsx
@@ -19,6 +19,7 @@ export interface FormProps<T>
   readOnly?: boolean;
   loading?: boolean;
   onSubmit?: (formState: TypedFormState<T>) => Promise<unknown>;
+  disableDefaultToast?: boolean;
   zodSchema?: ZodObject<ZodRawShape>;
 }
 
@@ -34,6 +35,7 @@ export function Form<T>({
   readOnly = false,
   disabled = false,
   loading = false,
+  disableDefaultToast,
   zodSchema,
   ...restProps
 }: FormProps<T>) {
@@ -41,6 +43,7 @@ export function Form<T>({
   const { handleSubmit, handleSubmitFailure, isSubmitting } =
     useDefaultSubmitActions<T>({
       onSubmit,
+      disableDefaultToast,
     });
 
   const contextValue = useMemo<FormContextType>(

--- a/packages/ui-informed/src/form/Form.tsx
+++ b/packages/ui-informed/src/form/Form.tsx
@@ -18,7 +18,7 @@ export interface FormProps<T>
   disabled?: boolean;
   readOnly?: boolean;
   loading?: boolean;
-  onSubmit?: (formState: TypedFormState<T>) => Promise<unknown>;
+  onSubmit?: (formState: TypedFormState<T>) => Promise<unknown> | void;
   disableDefaultToast?: boolean;
   zodSchema?: ZodObject<ZodRawShape>;
 }

--- a/packages/ui-informed/src/form/useDefaultSubmitActions.tsx
+++ b/packages/ui-informed/src/form/useDefaultSubmitActions.tsx
@@ -9,6 +9,7 @@ export interface TypedFormState<T> extends Omit<FormState, 'values'> {
 }
 type UseFormSubmitActionsParams<T> = {
   onSubmit?: (formState: TypedFormState<T>) => Promise<unknown>;
+  disableDefaultToast?: boolean;
 };
 
 /**
@@ -18,6 +19,7 @@ type UseFormSubmitActionsParams<T> = {
  */
 export function useDefaultSubmitActions<T>({
   onSubmit,
+  disableDefaultToast,
 }: UseFormSubmitActionsParams<T>) {
   const messages = useFormTranslationsContext();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -34,28 +36,36 @@ export function useDefaultSubmitActions<T>({
         await onSubmit?.(formState as TypedFormState<T>);
 
         // Show success notification
-        toast.success(messages.actions.success.title, {
-          description: messages.actions.success.message,
-        });
+        if (!disableDefaultToast) {
+          toast.success(messages.actions.success.title, {
+            description: messages.actions.success.message,
+          });
+        }
       } catch (error) {
-        toast.error(messages.actions.fail.title, {
-          description: (error as any).message,
-        });
+        if (!disableDefaultToast) {
+          toast.error(messages.actions.fail.title, {
+            description: (error as any).message,
+          });
+        } else {
+          throw error;
+        }
       } finally {
         setIsSubmitting(false);
       }
     },
-    [messages, onSubmit],
+    [disableDefaultToast, messages, onSubmit],
   );
 
   /**
    * Submit failure handler, shows notification with error message.
    */
   const handleSubmitFailure = useCallback(() => {
-    toast.error(messages.actions.fail.title, {
-      description: messages.actions.fail.message,
-    });
-  }, [messages]);
+    if (!disableDefaultToast) {
+      toast.error(messages.actions.fail.title, {
+        description: messages.actions.fail.message,
+      });
+    }
+  }, [disableDefaultToast, messages]);
 
   return {
     handleSubmit,

--- a/packages/ui-informed/src/form/useDefaultSubmitActions.tsx
+++ b/packages/ui-informed/src/form/useDefaultSubmitActions.tsx
@@ -8,7 +8,7 @@ export interface TypedFormState<T> extends Omit<FormState, 'values'> {
   values: T;
 }
 type UseFormSubmitActionsParams<T> = {
-  onSubmit?: (formState: TypedFormState<T>) => Promise<unknown>;
+  onSubmit?: (formState: TypedFormState<T>) => Promise<unknown> | void;
   disableDefaultToast?: boolean;
 };
 

--- a/packages/ui-informed/src/formControl/FormControl.tsx
+++ b/packages/ui-informed/src/formControl/FormControl.tsx
@@ -42,9 +42,7 @@ export interface FormItemProps
   className?: string;
   label?: string;
   name: string;
-  // according to https://github.com/teslamotors/informed/blob/master/src/utils.js#L100
-  // it seems that `type` is just these values:
-  type?: 'text' | 'textArea' | 'number' | 'select' | 'checkbox';
+  type?: string;
   disabled?: boolean;
   readOnly?: boolean;
   tooltip?: ReactNode;

--- a/packages/ui-informed/src/formControl/FormControl.tsx
+++ b/packages/ui-informed/src/formControl/FormControl.tsx
@@ -42,7 +42,9 @@ export interface FormItemProps
   className?: string;
   label?: string;
   name: string;
-  type?: string;
+  // according to https://github.com/teslamotors/informed/blob/master/src/utils.js#L100
+  // it seems that `type` is just these values:
+  type?: 'text' | 'textArea' | 'number' | 'select' | 'checkbox';
   disabled?: boolean;
   readOnly?: boolean;
   tooltip?: ReactNode;

--- a/packages/ui-informed/src/formControl/FormControl.tsx
+++ b/packages/ui-informed/src/formControl/FormControl.tsx
@@ -46,6 +46,7 @@ export interface FormItemProps
   disabled?: boolean;
   readOnly?: boolean;
   tooltip?: ReactNode;
+  hideOptional?: boolean;
   render: FormControlRender;
   zodItemSchema?: ZodType;
 }
@@ -64,6 +65,7 @@ export function FormControl({
   type = 'text',
   required,
   tooltip,
+  hideOptional,
   render,
   zodItemSchema,
   ...restProps
@@ -111,7 +113,9 @@ export function FormControl({
               </FormInfo>
             </Tooltip>
           )}
-          {!required && <FormInfo>({messages.labels.optional})</FormInfo>}
+          {!hideOptional && !required && (
+            <FormInfo>({messages.labels.optional})</FormInfo>
+          )}
         </Label>
       )}
       {/* Every wrapped component should pass render prop */}


### PR DESCRIPTION
inspired by changes on Wue:
- Add prop `hideOptional` to FormControl to hide 'optional' flag on labels
- Add prop `inputType` to Input to distinguish between input type and form control type
- Add prop `disableDefaultToast` to Form to disable default toast messages on submit